### PR TITLE
Registered import and export for YAML

### DIFF
--- a/Kernel/YAML.wl
+++ b/Kernel/YAML.wl
@@ -1,3 +1,5 @@
+(*:Package:*)
+
 (*
   This paclet provides a simple interface to the YAML library for importing and exporting YAML files.
   It has two functions: ImportYAML and ExportYAML.
@@ -5,39 +7,60 @@
   ExportYAML[file, data] exports a Dataset to a YAML file.
 *)
 
-BeginPackage["WolframExternalFunctions`YAML`"]
 
-ImportYAML::usage = "ImportYAML[file] imports a YAML file and returns a Dataset"
-ExportYAML::usage = "ExportYAML[file, data] exports a Dataset to a YAML file"
+BeginPackage["WolframExternalFunctions`YAML`"]; 
 
-Begin["`Private`"]
+
+ImportYAML::usage = "ImportYAML[file] imports a YAML file and returns a Dataset."; 
+
+
+ExportYAML::usage = "ExportYAML[file, data] exports a Dataset to a YAML file."; 
+
+
+Begin["`Private`"]; 
+
 
 $ThisDirectory = DirectoryName[$InputFileName];
 
+
 GetExternalSession[id_String, dependencies_List] := 
  Module[{env, session},
-  env = {"Python", "ID" -> id, 
-    "Evaluator" -> <|"Dependencies" -> dependencies, 
-      "EnvironmentName" -> id|>};
-  session = 
-   SelectFirst[ExternalSessions[], #["ID"] == id &, 
-    StartExternalSession[env]]
-  ]
+    env = {"Python", 
+        "ID" -> id, 
+        "Evaluator" -> <|
+            "Dependencies" -> dependencies, 
+            "EnvironmentName" -> id
+        |>
+    };
+    session = SelectFirst[ExternalSessions[], #["ID"] == id &, StartExternalSession[env]]
+]; 
+
 
 ImportYAML[file_] := Module[{session, result},
     session = GetExternalSession["PyYAML", {"PyYAML"}];
-    ExternalEvaluate[session, File[ FileNameJoin[{$ThisDirectory,"yaml.py"}]]];
-    result = ExternalEvaluate[session, "importyaml"->file];
+    ExternalEvaluate[session, File[FileNameJoin[{$ThisDirectory, "yaml.py"}]]];
+    result = ExternalEvaluate[session, "importyaml" -> file];
     Dataset[result]
-]  
+]; 
+
 
 ExportYAML[file_, data_] := Module[{session, result},
     session = GetExternalSession["PyYAML", {"PyYAML"}];
     ExternalEvaluate[session, File[ FileNameJoin[{$ThisDirectory,"yaml.py"}]]];
     result = ExternalEvaluate[session, "exportyaml"->{file,Normal[data]}];
-    
-]  
+]; 
 
-End[]
 
-EndPackage[]
+ImportExport`RegisterFormat["*.yaml", "Extensions" -> "YAML"]; 
+
+
+ImportExport`RegisterImport["YAML", WolframExternalFunctions`YAML`ImportYAML]; 
+
+
+ImportExport`RegisterExport["YAML", WolframExternalFunctions`YAML`ExportYAML]; 
+
+
+End[]; 
+
+
+EndPackage[]; 

--- a/PacletInfo.wl
+++ b/PacletInfo.wl
@@ -1,8 +1,10 @@
+(* ::Package:: *)
+
 PacletObject[ <|
     "Name" -> "WolframExternalFunctions/YAML",
     "Description" -> "A package for reading and writing YAML files", 
     "Creator" -> "Arnoud Buzing",
-    "Version" -> "1.0.0",
+    "Version" -> "1.0.1",
     "WolframVersion" -> "14.0+",
     "PublisherID" -> "WolframExternalFunctions",
     "License" -> "MIT",


### PR DESCRIPTION
The following became available: 

```wolfram
Import["file.yaml", "YAML"]
Export["file.yaml", {1, 2, 3}, "YAML"]
ImportString[yaml, "YAML"]
ExportString[{1, 2, 3}, "YAML"]
```